### PR TITLE
force update.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.10
+FROM python:3.9.10-bullseye
 
 ENV PIP_NO_CACHE_DIR 1
 ENV LANG C.UTF-8


### PR DESCRIPTION
I've noticed that on some instances just changing py version doesn't upgrade it. So telling it to use bullseye docker makes it upgrade Linux.
Change it for gpack too.